### PR TITLE
Add basic iterm2 support

### DIFF
--- a/colors/iterm2_sacredforest.vim
+++ b/colors/iterm2_sacredforest.vim
@@ -1,0 +1,146 @@
+" VIM COLOR SCHEME
+" Maintainer:   Karolis Koncevicius
+" Inspirations: nova, zenburn
+
+hi clear
+
+if exists('syntax_on')
+  syntax reset
+endif
+
+let g:colors_name='sacredforest'
+
+set background=dark
+
+hi Normal           ctermbg=0    ctermfg=7     cterm=NONE      guibg=#3C4C55 guifg=#FFEBC3   gui=NONE
+
+hi Comment          ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+hi Special          ctermbg=NONE ctermfg=3     cterm=NONE      guibg=NONE    guifg=#b2a488   gui=NONE
+hi Statement        ctermbg=NONE ctermfg=3     cterm=NONE      guibg=NONE    guifg=#b2a488   gui=NONE
+hi Type             ctermbg=NONE ctermfg=3     cterm=NONE      guibg=NONE    guifg=#b2a488   gui=NONE
+hi Function         ctermbg=NONE ctermfg=3     cterm=NONE      guibg=NONE    guifg=#b2a488   gui=NONE
+hi PreProc          ctermbg=NONE ctermfg=3     cterm=NONE      guibg=NONE    guifg=#b2a488   gui=NONE
+
+hi Identifier       ctermbg=NONE ctermfg=2     cterm=NONE      guibg=NONE    guifg=#a8ce93   gui=NONE
+hi Constant         ctermbg=NONE ctermfg=2     cterm=NONE      guibg=NONE    guifg=#a8ce93   gui=NONE
+hi Boolean          ctermbg=NONE ctermfg=2     cterm=NONE      guibg=NONE    guifg=#a8ce93   gui=NONE
+hi String           ctermbg=NONE ctermfg=2     cterm=NONE      guibg=NONE    guifg=#a8ce93   gui=NONE
+hi Title            ctermbg=NONE ctermfg=12    cterm=NONE      guibg=NONE    guifg=#c5d4dd   gui=NONE
+
+hi LineNr           ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+hi CursorLineNr     ctermbg=NONE ctermfg=11    cterm=NONE      guibg=NONE    guifg=#ddd668   gui=NONE
+hi MatchParen       ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+hi Conceal          ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+hi SpecialKey       ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+hi ColorColumn      ctermbg=8    ctermfg=NONE  cterm=NONE      guibg=#616c72 guifg=NONE      gui=NONE
+hi SignColumn       ctermbg=8    ctermfg=NONE  cterm=NONE      guibg=#616c72 guifg=NONE      gui=NONE
+hi Folded           ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+hi FoldColumn       ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+
+hi Directory        ctermbg=NONE ctermfg=2     cterm=NONE      guibg=NONE    guifg=#a8ce93   gui=NONE
+hi Underlined       ctermbg=NONE ctermfg=NONE  cterm=UNDERLINE guibg=NONE    guifg=NONE      gui=UNDERLINE
+
+hi Visual           ctermbg=6    ctermfg=0     cterm=NONE      guibg=#7fc1ca guifg=#3c4c55   gui=NONE
+hi VisualNOS        ctermbg=NONE ctermfg=NONE  cterm=UNDERLINE guibg=NONE    guifg=NONE      gui=UNDERLINE
+hi IncSearch        ctermbg=220  ctermfg=0     cterm=NONE      guibg=#edc202 guifg=#3c4c55   gui=NONE
+hi Search           ctermbg=11   ctermfg=0     cterm=NONE      guibg=#ddd668 guifg=#3c4c55   gui=NONE
+
+hi StatusLine       ctermbg=8    ctermfg=7     cterm=NONE      guibg=#616c72 guifg=#ffebc3   gui=NONE
+hi StatusLineNC     ctermbg=8    ctermfg=7     cterm=NONE      guibg=#616c72 guifg=#ffebc3   gui=NONE
+hi VertSplit        ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+hi WildMenu         ctermbg=7    ctermfg=8     cterm=NONE      guibg=#ffebc3 guifg=#616c72   gui=NONE
+hi ModeMsg          ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+
+hi DiffAdd          ctermbg=10   ctermfg=0     cterm=NONE      guibg=#8eaf6b guifg=#3c4c55   gui=NONE
+hi DiffDelete       ctermbg=1    ctermfg=0     cterm=NONE      guibg=#db6c6c guifg=#3c4c55   gui=NONE
+hi DiffChange       ctermbg=0    ctermfg=5     cterm=UNDERLINE guibg=#3c4c55 guifg=#ffbf00   gui=UNDERLINE
+hi DiffText         ctermbg=5    ctermfg=0     cterm=NONE      guibg=#ffbf00 guifg=#3c4c55   gui=NONE
+
+hi Pmenu            ctermbg=8    ctermfg=7     cterm=NONE      guibg=#616c72 guifg=#ffebc3   gui=NONE
+hi PmenuSel         ctermbg=8    ctermfg=7     cterm=REVERSE   guibg=#616c72 guifg=#ffebc3   gui=REVERSE
+hi PmenuSbar        ctermbg=8    ctermfg=NONE  cterm=NONE      guibg=#616c72 guifg=NONE      gui=NONE
+hi PmenuThumb       ctermbg=7    ctermfg=NONE  cterm=NONE      guibg=#ffebc3 guifg=NONE      gui=NONE
+
+hi SpellBad         ctermbg=NONE ctermfg=NONE  cterm=UNDERCURL guibg=NONE    guifg=NONE      gui=UNDERCURL
+hi SpellCap         ctermbg=NONE ctermfg=NONE  cterm=UNDERCURL guibg=NONE    guifg=NONE      gui=UNDERCURL
+hi SpellLocal       ctermbg=NONE ctermfg=NONE  cterm=UNDERCURL guibg=NONE    guifg=NONE      gui=UNDERCURL
+hi SpellRare        ctermbg=NONE ctermfg=NONE  cterm=UNDERCURL guibg=NONE    guifg=NONE      gui=UNDERCURL
+
+hi ErrorMsg         ctermbg=1    ctermfg=8     cterm=NONE      guibg=#db6c6c guifg=#616c72   gui=NONE
+hi WarningMsg       ctermbg=NONE ctermfg=1     cterm=NONE      guibg=NONE    guifg=#db6c6c   gui=NONE
+hi MoreMsg          ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+hi Question         ctermbg=NONE ctermfg=6     cterm=NONE      guibg=NONE    guifg=#7fc1ca   gui=NONE
+
+hi TabLine          ctermbg=8    ctermfg=7     cterm=NONE      guibg=#616c72 guifg=#ffebc3   gui=NONE
+hi TabLineSel       ctermbg=8    ctermfg=7     cterm=REVERSE   guibg=#616c72 guifg=#ffebc3   gui=REVERSE
+hi TabLineFill      ctermbg=8    ctermfg=7     cterm=NONE      guibg=#616c72 guifg=#ffebc3   gui=NONE
+
+hi Error            ctermbg=NONE ctermfg=1     cterm=REVERSE   guibg=NONE    guifg=#db6c6c   gui=REVERSE
+hi Ignore           ctermbg=NONE ctermfg=NONE  cterm=NONE      guibg=NONE    guifg=NONE      gui=NONE
+hi Todo             ctermbg=7    ctermfg=8     cterm=NONE      guibg=#ffebc3 guifg=#616c72   gui=NONE
+
+hi NonText          ctermbg=NONE ctermfg=8     cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
+
+hi Cursor           ctermbg=7    ctermfg=NONE  cterm=NONE      guibg=#ffebc3 guifg=NONE      gui=NONE
+hi CursorColumn     ctermbg=4    ctermfg=NONE  cterm=NONE      guibg=#4c5866 guifg=NONE      gui=NONE
+hi CursorLine       ctermbg=0    ctermfg=NONE  cterm=NONE      guibg=#4c5866 guifg=NONE      gui=NONE
+
+hi helpleadblank    ctermbg=NONE ctermfg=NONE  cterm=NONE      guibg=NONE    guifg=NONE      gui=NONE
+hi helpnormal       ctermbg=NONE ctermfg=NONE  cterm=NONE      guibg=NONE    guifg=NONE      gui=NONE
+
+
+hi link Number             Constant
+hi link Character          Constant
+
+hi link Conditional        Statement
+hi link Debug              Special
+hi link Define             PreProc
+hi link Delimiter          Special
+hi link Exception          Statement
+hi link Float              Number
+hi link HelpCommand        Statement
+hi link HelpExample        Statement
+hi link Include            PreProc
+hi link Keyword            Statement
+hi link Label              Statement
+hi link Macro              PreProc
+hi link Operator           Statement
+hi link PreCondit          PreProc
+hi link Repeat             Statement
+hi link SpecialChar        Special
+hi link SpecialComment     Special
+hi link StorageClass       Type
+hi link Structure          Type
+hi link Tag                Special
+hi link Typedef            Type
+
+hi link htmlEndTag         htmlTagName
+hi link htmlLink           Function
+hi link htmlSpecialTagName htmlTagName
+hi link htmlTag            htmlTagName
+hi link xmlTag             Statement
+hi link xmlTagName         Statement
+hi link xmlEndTag          Statement
+
+hi link markdownItalic     Preproc
+
+hi link diffBDiffer        WarningMsg
+hi link diffCommon         WarningMsg
+hi link diffDiffer         WarningMsg
+hi link diffIdentical      WarningMsg
+hi link diffIsA            WarningMsg
+hi link diffNoEOL          WarningMsg
+hi link diffOnly           WarningMsg
+hi link diffRemoved        WarningMsg
+hi link diffAdded          String
+
+hi link vimHiAttrib        Constant
+hi link vimParenSep        Normal
+hi link vimVar             Normal
+hi link vimFuncVar         Normal
+hi link vimMapMod          Identifier
+hi link vimMapModKey       Identifier
+hi link vimNotation        Identifier
+hi link vimBracket         Identifier
+
+hi link QuickFixLine       Visual

--- a/iterm2-colors/sacredforest.itermcolors
+++ b/iterm2-colors/sacredforest.itermcolors
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.3333333432674408</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.29803922772407532</real>
+		<key>Red Component</key>
+		<real>0.23529411852359772</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.42352941632270813</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.42352941632270813</real>
+		<key>Red Component</key>
+		<real>0.85882353782653809</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.41960784792900085</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.68627452850341797</real>
+		<key>Red Component</key>
+		<real>0.55686277151107788</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.40784314274787903</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.83921569585800171</real>
+		<key>Red Component</key>
+		<real>0.86666667461395264</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.86666667461395264</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.83137255907058716</real>
+		<key>Red Component</key>
+		<real>0.77254903316497803</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.74901962280273438</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.7921568751335144</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.75686275959014893</real>
+		<key>Red Component</key>
+		<real>0.49803921580314636</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.76470589637756348</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.92156863212585449</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.57647061347961426</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.80784314870834351</real>
+		<key>Red Component</key>
+		<real>0.65882354974746704</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.53333336114883423</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.64313727617263794</real>
+		<key>Red Component</key>
+		<real>0.69803923368453979</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.40000000596046448</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.34509804844856262</real>
+		<key>Red Component</key>
+		<real>0.29803922772407532</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.74901962280273438</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.7921568751335144</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.75686275959014893</real>
+		<key>Red Component</key>
+		<real>0.49803921580314636</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.76470589637756348</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.92156863212585449</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.44705882668495178</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.42352941632270813</real>
+		<key>Red Component</key>
+		<real>0.3803921639919281</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.42352941632270813</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.42352941632270813</real>
+		<key>Red Component</key>
+		<real>0.85882353782653809</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.3333333432674408</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.29803922772407532</real>
+		<key>Red Component</key>
+		<real>0.23529411852359772</real>
+	</dict>
+	<key>Badge Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.5</real>
+		<key>Blue Component</key>
+		<real>0.42352941632270813</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.42352941632270813</real>
+		<key>Red Component</key>
+		<real>0.85882353782653809</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.76470589637756348</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.92156863212585449</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.76470589637756348</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.92156863212585449</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.25</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.9268307089805603</real>
+		<key>Red Component</key>
+		<real>0.70213186740875244</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.3333333432674408</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.29803922772407532</real>
+		<key>Red Component</key>
+		<real>0.23529411852359772</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.76470589637756348</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.92156863212585449</real>
+		<key>Red Component</key>
+		<real>1</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.57647061347961426</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.80784314870834351</real>
+		<key>Red Component</key>
+		<real>0.65882354974746704</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.3333333432674408</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.29803922772407532</real>
+		<key>Red Component</key>
+		<real>0.23529411852359772</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.7921568751335144</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.75686275959014893</real>
+		<key>Red Component</key>
+		<real>0.49803921580314636</real>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
I really like this colorscheme, and wanted to be able to use it in iterm2. To set it up, you have to import the iterm2 colorscheme, then you have to change the `cterm` values in the `vim` colorscheme. There's more sophisticated ways of doing it through vimscript variables/etc, but I just added another version of the colorscheme file, `iterm2_sacredforest.vim`. Anyways, if this is useful at all, let me know! I'm pretty sure it's all working, although `set cursorline` has to be done by the user.

Edit: To clarify, I think in general `set termguicolors` should be the intended solution, however I have had the darndest time trying to get it to work with tmux + iterm2! I'm not sure what the problem is exactly, but the solution that actually worked was to just change the iterm2 color palette and then use the cterm values in the vim colorscheme.