### PR TITLE
added color config for kitty

### DIFF
--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1,0 +1,48 @@
+# Drop these into your kitty.conf
+
+# Foreground color
+foreground           #ffebc3
+
+# Background color
+background           #3c4c55
+
+# Cursor color
+cursor               #ffebc3
+
+# Selection foreground color
+selection_foreground #3c4c55
+
+# Selection background color
+selection_background #ffebc3
+
+# Black
+color0               #3c4c55
+color8               #4c5866
+
+# Red
+color1               #db6c6c
+color9               #f88379
+
+# Green
+color2               #8eaf6b
+color10              #a8ce93
+
+# Yellow
+color3               #ffbf00
+color11              #ddd668
+
+# Blue
+color4               #3ba2cc
+color12              #7fc1ca
+
+# Magenta
+color5               #907eb5
+color13              #ae8fc1
+
+# Cyan
+color6               #c5d4dd
+color14              #616c72
+
+# White
+color7               #ffebc3
+color15              #b2a488


### PR DESCRIPTION
Hey there! I've had my eye on this colorscheme for a while now, and the added lightline support made it so I could add it to my vim setup :) however using kitty, setting colors can be a pain, and I've noticed a lot of vim colorscheme repos have config files for a variety of terminals. So I have added the config for kitty so people can just copy and paste and get this theme working in their terminal. If this isn't something you want for the project no worries 😄 