### PR TITLE
Make character under cursor visible

### DIFF
--- a/colors/sacredforest.vim
+++ b/colors/sacredforest.vim
@@ -83,7 +83,7 @@ hi Todo             ctermbg=7    ctermfg=14    cterm=NONE      guibg=#e0d7c3 gui
 
 hi NonText          ctermbg=NONE ctermfg=14    cterm=NONE      guibg=NONE    guifg=#616c72   gui=NONE
 
-hi Cursor           ctermbg=7    ctermfg=NONE  cterm=NONE      guibg=#e0d7c3 guifg=NONE      gui=NONE
+hi Cursor           ctermbg=7    ctermfg=0     cterm=NONE      guibg=#e0d7c3 guifg=#3c4c55   gui=NONE
 hi CursorColumn     ctermbg=8    ctermfg=NONE  cterm=NONE      guibg=#4c5866 guifg=NONE      gui=NONE
 hi CursorLine       ctermbg=8    ctermfg=NONE  cterm=NONE      guibg=#4c5866 guifg=NONE      gui=NONE
 


### PR DESCRIPTION
Prior to this commit, it was possible (in some cases)
for the bg and fg colors at the cursor to be the same,
resulting in the cursor hiding the character underneath it.

(I personally only noticed this in gvim,
but thought it would be safer to explicitly set the color
in the terminal, as well.)

This commit fixes this issue by setting the fg/bg of the cursor
to the inverse of the fg/bg colors in normal mode (`hi Normal`).